### PR TITLE
fix: Add docs/ prefix to cleanup branch detection

### DIFF
--- a/scripts/workflow-helper.sh
+++ b/scripts/workflow-helper.sh
@@ -355,7 +355,7 @@ case "$1" in
         
         # Clean up local branches
         echo "${CYAN}🔍 Checking local branches...${NC}"
-        MERGED_BRANCHES=$(git branch --merged | grep -E "(feat/|fix/|chore/)" | grep -v "\*" | tr -d ' ')
+        MERGED_BRANCHES=$(git branch --merged | grep -E "(feat/|fix/|chore/|docs/)" | grep -v "\*" | tr -d ' ')
         
         if [ -n "$MERGED_BRANCHES" ]; then
             echo "${YELLOW}Deleting local merged branches:${NC}"
@@ -373,7 +373,7 @@ case "$1" in
         gf_git_fetch origin
         
         # Get ALL remote feature branches (not just merged ones, since squash merges don't show as merged)
-        ALL_REMOTE_BRANCHES=$(git branch -r | grep -E "origin/(feat/|fix/|chore/)" | sed 's|origin/||' | sed 's|^[[:space:]]*||' | tr -d ' ')
+        ALL_REMOTE_BRANCHES=$(git branch -r | grep -E "origin/(feat/|fix/|chore/|docs/)" | sed 's|origin/||' | sed 's|^[[:space:]]*||' | tr -d ' ')
         
         # Check each branch via GitHub API to see if its PR is merged
         REMOTE_MERGED_BRANCHES=""


### PR DESCRIPTION
## 🐛 Problem

The cleanup command wasn't detecting `docs/` branches, causing them to persist after PR merges.

**Example**: `docs/squash-merge-troubleshooting-and-sourcery-feedback` remained after PRs #16 and #17 were merged.

## 🔍 Root Cause

The cleanup command only looked for these branch prefixes:
- `feat/`
- `fix/`
- `chore/`

But **NOT** `docs/` branches.

## ✅ Solution

Added `docs/` to the branch prefix pattern in both:
1. **Local branch cleanup** (line 358)
2. **Remote branch cleanup** (line 376)

**Pattern now**: `feat/|fix/|chore/|docs/`

## 🧪 Testing

✅ Successfully detected and deleted `docs/squash-merge-troubleshooting-and-sourcery-feedback`  
✅ `cleanup --yes` now working for docs/ branches  
✅ All branch types now properly handled

## 📝 Changes

```diff
- grep -E "origin/(feat/|fix/|chore/)"
+ grep -E "origin/(feat/|fix/|chore/|docs/)"
```

## 🎯 Impact

- Ensures all conventional branch prefixes are cleaned up
- Prevents branch accumulation for documentation PRs
- Consistent cleanup behavior across branch types

## Summary by Sourcery

Add docs/ prefix to branch cleanup patterns to ensure documentation branches are detected and deleted

Bug Fixes:
- Detect and delete docs/ branches in local cleanup
- Detect and delete docs/ branches in remote cleanup