### PR TITLE
feat: Parameterize Docker seeding timeout

### DIFF
--- a/admin/docs/troubleshooting/docker-seeding-timeout.md
+++ b/admin/docs/troubleshooting/docker-seeding-timeout.md
@@ -24,7 +24,17 @@ curl -s "http://localhost/api/v1/pokemon?per_page=1000" | \
 ```
 
 ### **Quick Fix** (for 649 Pokemon):
-1. Update `scripts/core/docker-startup.sh` line 22: `timeout 120s`
+
+**Option A: Environment Variables (Recommended)** ✅
+1. Update `.env` file:
+   ```bash
+   POKEMON_SEEDING_TIMEOUT=120
+   HEALTHCHECK_START_PERIOD=130
+   ```
+2. Rebuild: `docker compose down && docker compose build --no-cache && docker compose up -d`
+
+**Option B: Direct File Edit**
+1. Update `scripts/core/docker-startup.sh` line 23: `SEEDING_TIMEOUT=120`
 2. Update `docker-compose.yml` line 22: `start_period: 130s`
 3. Rebuild: `docker compose down && docker compose build --no-cache && docker compose up -d`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 130s
+      start_period: ${HEALTHCHECK_START_PERIOD:-130}s
 
   redis:
     image: redis:7-alpine

--- a/env.example
+++ b/env.example
@@ -23,6 +23,16 @@ POKEAPI_BASE_URL=https://pokeapi.co/api/v2
 JWT_SECRET_KEY=your-jwt-secret-key-here
 JWT_ACCESS_TOKEN_EXPIRES=3600
 
+# Docker Configuration
+# Pokemon seeding timeout (seconds) - adjust based on number of Pokemon
+# Formula: (Total Pokemon × 0.2s) + 30s buffer
+# Default: 120s for 649 Pokemon (Gen 1-5)
+POKEMON_SEEDING_TIMEOUT=120
+
+# Docker health check start period (seconds) - should be timeout + 10s buffer
+# Default: 130s (120s timeout + 10s buffer)
+HEALTHCHECK_START_PERIOD=130
+
 # Production Configuration
 # Set these in production
 # FLASK_ENV=production

--- a/scripts/core/docker-startup.sh
+++ b/scripts/core/docker-startup.sh
@@ -19,7 +19,8 @@ with app.app_context():
 
 # Seed Pokemon data (with timeout and error handling)
 echo "🌱 Seeding Pokemon data..."
-cd /app && timeout 120s python -c "
+SEEDING_TIMEOUT=${POKEMON_SEEDING_TIMEOUT:-120}
+cd /app && timeout ${SEEDING_TIMEOUT}s python -c "
 from backend.app import app
 from backend.utils.pokemon_seeder import pokemon_seeder
 with app.app_context():
@@ -30,7 +31,7 @@ with app.app_context():
         print(f'⚠️ Pokemon seeding failed: {e}')
         print('🔄 Application will continue without seeded data')
 " || {
-    echo "⚠️ Pokemon seeding timed out after 120 seconds"
+    echo "⚠️ Pokemon seeding timed out after ${SEEDING_TIMEOUT} seconds"
     echo "🔄 Application will continue without seeded data"
 }
 


### PR DESCRIPTION
## 🎯 Sourcery Recommendation #8 (MEDIUM Priority)

> "Consider parameterizing the seeding timeout (and corresponding healthcheck start_period) via environment variables or a shared config so you don't need to hard-code matching values in multiple files."

## ✅ Implementation

### **1. Added Environment Variables**
`env.example`:
```bash
# Docker Configuration
POKEMON_SEEDING_TIMEOUT=120        # Seeding timeout in seconds
HEALTHCHECK_START_PERIOD=130       # Health check start period
```

**Includes**:
- Formula: `(Total Pokemon × 0.2s) + 30s buffer`
- Default values with explanations
- Usage guidance in comments

### **2. Updated docker-compose.yml**
```yaml
healthcheck:
  start_period: ${HEALTHCHECK_START_PERIOD:-130}s
```
- Uses environment variable with fallback to 130s
- No breaking changes (defaults work)

### **3. Updated docker-startup.sh**
```bash
SEEDING_TIMEOUT=${POKEMON_SEEDING_TIMEOUT:-120}
timeout ${SEEDING_TIMEOUT}s python -c "..."
```
- Reads environment variable with default
- Dynamic timeout message shows actual value

### **4. Updated Troubleshooting Guide**
- Added "Option A: Environment Variables" (recommended)
- Kept "Option B: Direct File Edit" for reference
- Clear guidance for both approaches

---

## 📊 Benefits

### **Single Source of Truth** ✅
**Before**:
- `docker-startup.sh` line 23: `timeout 120s`
- `docker-compose.yml` line 22: `start_period: 130s`
- Risk of mismatched values

**After**:
- `.env`: `POKEMON_SEEDING_TIMEOUT=120`
- `.env`: `HEALTHCHECK_START_PERIOD=130`
- One place to update both values

### **Easier Configuration** ✅
**Before**: Edit 2 files, rebuild
**After**: Edit `.env`, rebuild

### **Environment-Specific** ✅
- Development: 120s (Gen 1-5)
- CI/CD: Can use shorter timeout for testing
- Production: Can use longer timeout for more generations

### **Future-Proof** ✅
When adding Gen 6+ Pokemon:
```bash
# Just update .env
POKEMON_SEEDING_TIMEOUT=180  # For more Pokemon
HEALTHCHECK_START_PERIOD=190
```

---

## 🧪 Testing

### **Default Behavior (No Changes Required)**:
```bash
docker compose down
docker compose build --no-cache
docker compose up -d
# Uses defaults: 120s timeout, 130s health check
```

### **Custom Timeout**:
```bash
# Add to .env
POKEMON_SEEDING_TIMEOUT=180
HEALTHCHECK_START_PERIOD=190

docker compose down
docker compose build --no-cache
docker compose up -d
# Uses custom values
```

### **Fallback Behavior**:
- If vars not set → uses defaults (120s/130s)
- No breaking changes
- Backwards compatible

---

## 📝 Files Changed

| File | Change | Purpose |
|------|--------|---------|
| `env.example` | Added 2 env vars | Configuration template |
| `docker-compose.yml` | Use ${HEALTHCHECK_START_PERIOD:-130}s | Dynamic health check |
| `docker-startup.sh` | Use ${POKEMON_SEEDING_TIMEOUT:-120} | Dynamic timeout |
| `docker-seeding-timeout.md` | Updated quick fix | Document new approach |

---

## ✅ Validation

- ✅ Defaults work without changes
- ✅ Environment variables override defaults
- ✅ Fallback values prevent errors
- ✅ Troubleshooting guide updated
- ✅ No breaking changes

---

**Sourcery Recommendation**: ✅ IMPLEMENTED  
**Priority**: 🟡 MEDIUM  
**Impact**: Reduces duplication, improves maintainability  
**Effort**: LOW (4 files, ~25 lines changed)

## Summary by Sourcery

Parameterize Docker seeding timeout and healthcheck start period via environment variables to centralize configuration and avoid hard-coded values.

Enhancements:
- Parameterize seeding timeout in docker-startup.sh using POKEMON_SEEDING_TIMEOUT with a default fallback
- Configure healthcheck start_period in docker-compose.yml using HEALTHCHECK_START_PERIOD with a default fallback

Documentation:
- Add POKEMON_SEEDING_TIMEOUT and HEALTHCHECK_START_PERIOD to env.example with explanatory comments
- Update troubleshooting guide to recommend environment variable–based configuration for seeding timeout