### PR TITLE
fix(ci): capture template validation output in artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,16 +177,16 @@ jobs:
       - name: Run template validation
         run: |
           chmod +x scripts/validate-templates.sh
-          ./scripts/validate-templates.sh
+          mkdir -p template-validation-results
+          ./scripts/validate-templates.sh > template-validation-results/validation-output.txt 2>&1
+          echo "Template validation exit code: $?" >> template-validation-results/validation-output.txt
 
       - name: Upload validation results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: template-validation-results
-          path: |
-            scripts/validate-templates.sh
-            admin/planning/notes/opportunities/external/administration/templates/
+          path: template-validation-results/
           if-no-files-found: ignore
 
   test:

--- a/admin/feedback/cursor-bugbot/pr45.md
+++ b/admin/feedback/cursor-bugbot/pr45.md
@@ -1,0 +1,121 @@
+# Cursor Bugbot Review Analysis
+**PR**: #45
+**Repository**: grimm00/pokehub
+**Generated**: 2025-01-20
+
+---
+
+## Summary
+
+Total Issues: 1
+
+## Issues
+
+### Issue #1
+
+**Location**: `.github/workflows/ci.yml:182-190`
+
+**Type**: Bug
+
+**Description**: Template Validation Artifacts Missing Output
+
+The template-validation job's artifact upload is configured to include source files (scripts/validate-templates.sh and the templates directory) instead of actual validation output. As the validation script prints to stdout/stderr and doesn't generate files, the uploaded artifact won't contain useful debugging information for failures.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
+      - name: Upload validation results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: template-validation-results
+          path: |
+            scripts/validate-templates.sh
+            admin/planning/notes/opportunities/external/administration/templates/
+          if-no-files-found: ignore
+</code></pre>
+
+<b>Issue</b>
+
+**Bug:** The artifact upload captures source files instead of validation output, making debugging difficult when validation fails.
+
+</details>
+
+---
+
+## Priority Matrix Assessment
+
+Use this template to assess each issue:
+
+| Issue | Priority | Impact | Effort | Notes |
+|-------|----------|--------|--------|-------|
+| #1 | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | Artifact output issue - affects debugging |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+---
+
+## 📊 Detailed Analysis
+
+### Issue #1: Template Validation Artifacts Missing Output
+**Priority:** 🟡 MEDIUM | **Impact:** 🟡 MEDIUM | **Effort:** 🟢 LOW
+
+**Issue:** The template validation job uploads source files instead of actual validation output, making debugging difficult.
+
+**Root Cause:** The validation script prints to stdout/stderr but doesn't generate files, so the artifact upload captures the wrong content.
+
+**Recommended Fix:**
+```yaml
+- name: Run template validation
+  run: |
+    chmod +x scripts/validate-templates.sh
+    mkdir -p template-validation-results
+    ./scripts/validate-templates.sh > template-validation-results/validation-output.txt 2>&1
+    echo "Template validation exit code: $?" >> template-validation-results/validation-output.txt
+
+- name: Upload validation results
+  uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: template-validation-results
+    path: template-validation-results/
+    if-no-files-found: ignore
+```
+
+**Impact:** Improves debugging experience when template validation fails by providing actual validation output instead of source files.
+
+---
+
+## 🚀 Recommended Action Plan
+
+### Phase 1: Critical Fixes (Immediate)
+1. **Fix Issue #1** - Update template validation artifacts to capture output (MEDIUM priority)
+
+**Estimated Total Effort:** 15 minutes.
+
+---
+
+## 🎯 Conclusion
+
+**Cursor Bugbot identified 1 valid issue with the template validation CI job.** The artifact upload configuration needs to be updated to capture actual validation output instead of source files. This is a straightforward fix that will improve the debugging experience when template validation fails.
+
+**The fix has been implemented and is ready for testing!** 🎉

--- a/admin/feedback/sourcery/pr45.md
+++ b/admin/feedback/sourcery/pr45.md
@@ -1,0 +1,132 @@
+# Sourcery Review Analysis
+**PR**: #45
+**Repository**: grimm00/pokehub
+**Generated**: Fri Oct 10 09:36:47 CDT 2025
+
+---
+
+## Summary
+
+Total Individual Comments: 2 + Overall Comments
+
+## Individual Comments
+
+### Comment #1
+
+**Location**: `scripts/validate-templates.sh:135-138`
+
+**Type**: suggestion (bug_risk)
+
+**Description**: Consider anchoring the grep pattern to the start of the line or using more specific patterns to avoid matching section text in comments or other parts of the file.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++    
++    # Check each required section
++    for section in &quot;${required_sections[@]}&quot;; do
++        if grep -q &quot;$section&quot; &quot;$template_file&quot;; then
++            log_success &quot;  ✓ Section found: $section&quot;
++        else
+</code></pre>
+
+<b>Issue</b>
+
+**suggestion (bug_risk):** Potential false positives if section text appears elsewhere.
+
+<b>Suggestion</b>
+
+<pre><code>
+    for section in &quot;${required_sections[@]}&quot;; do
+        if grep -Eq &quot;^${section}&quot; &quot;$template_file&quot;; then
+            log_success &quot;  ✓ Section found: \&quot;$section\&quot;&quot;
+        else
+</code></pre>
+
+</details>
+
+---
+
+### Comment #2
+
+**Location**: `scripts/validate-templates.sh:192-199`
+
+**Type**: suggestion
+
+**Description**: Add a check to verify that the glob matches existing directories before iterating to prevent unexpected behavior.
+
+<details>
+<summary>Details</summary>
+
+<b>Code Context</b>
+
+<pre><code>
++
++# Check projects in features directory
++if [ -d &quot;$PROJECTS_DIR/features&quot; ]; then
++    for project_dir in &quot;$PROJECTS_DIR/features&quot;/*/; do
++        if [ -d &quot;$project_dir&quot; ]; then
++            check_project_compliance &quot;$project_dir&quot;
+</code></pre>
+
+<b>Issue</b>
+
+**suggestion:** Globbing may fail if no directories exist.
+
+<b>Suggestion</b>
+
+<pre><code>
+# Check projects in features directory
+if [ -d &quot;$PROJECTS_DIR/features&quot; ]; then
+    feature_dirs=( &quot;$PROJECTS_DIR/features&quot;/*/ )
+    if [ -d &quot;${feature_dirs[0]}&quot; ]; then
+        for project_dir in &quot;${feature_dirs[@]}&quot;; do
+            if [ -d &quot;$project_dir&quot; ]; then
+                check_project_compliance &quot;$project_dir&quot;
+            fi
+        done
+    fi
+fi
+</code></pre>
+
+</details>
+
+---
+
+## Overall Comments
+
+- The CI workflow artifact upload currently grabs the script and template files—update it to capture the actual validation logs or a dedicated results file so failures can be reviewed easily.
+- The validation script’s hard-coded lists of templates and required sections could be externalized into a config (e.g. YAML/JSON) to simplify maintenance as templates evolve.
+- Consider refactoring the large bash script into smaller, reusable functions or modules to improve readability and ease future enhancements.
+
+## Priority Matrix Assessment
+
+Use this template to assess each comment:
+
+| Comment | Priority | Impact | Effort | Notes |
+|---------|----------|--------|--------|-------|
+| #1 | | | | |
+| #2 | | | | |
+
+### Priority Levels
+- 🔴 **CRITICAL**: Security, stability, or core functionality issues
+- 🟠 **HIGH**: Bug risks or significant maintainability issues
+- 🟡 **MEDIUM**: Code quality and maintainability improvements
+- 🟢 **LOW**: Nice-to-have improvements
+
+### Impact Levels
+- 🔴 **CRITICAL**: Affects core functionality
+- 🟠 **HIGH**: User-facing or significant changes
+- 🟡 **MEDIUM**: Developer experience improvements
+- 🟢 **LOW**: Minor improvements
+
+### Effort Levels
+- 🟢 **LOW**: Simple, quick changes
+- 🟡 **MEDIUM**: Moderate complexity
+- 🟠 **HIGH**: Complex refactoring
+- 🔴 **VERY_HIGH**: Major rewrites
+
+

--- a/admin/feedback/sourcery/pr45.md
+++ b/admin/feedback/sourcery/pr45.md
@@ -108,8 +108,8 @@ Use this template to assess each comment:
 
 | Comment | Priority | Impact | Effort | Notes |
 |---------|----------|--------|--------|-------|
-| #1 | | | | |
-| #2 | | | | |
+| #1 | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | Grep pattern could match false positives - needs anchoring |
+| #2 | 🟡 MEDIUM | 🟡 MEDIUM | 🟢 LOW | Globbing may fail if no directories exist - needs safety check |
 
 ### Priority Levels
 - 🔴 **CRITICAL**: Security, stability, or core functionality issues
@@ -128,5 +128,96 @@ Use this template to assess each comment:
 - 🟡 **MEDIUM**: Moderate complexity
 - 🟠 **HIGH**: Complex refactoring
 - 🔴 **VERY_HIGH**: Major rewrites
+
+---
+
+## 📊 Detailed Analysis
+
+### Comment #1: Grep Pattern False Positives
+**Priority:** 🟡 MEDIUM | **Impact:** 🟡 MEDIUM | **Effort:** 🟢 LOW
+
+**Issue:** The grep pattern `"$section"` could match section text in comments or other parts of the file, leading to false positives.
+
+**Root Cause:** Using unanchored grep patterns that match anywhere in the file instead of at the beginning of lines.
+
+**Recommended Fix:**
+```bash
+# Current (problematic)
+if grep -q "$section" "$template_file"; then
+
+# Fixed (anchored)
+if grep -Eq "^${section}" "$template_file"; then
+```
+
+**Impact:** Prevents false positive matches when section text appears in comments or other contexts.
+
+---
+
+### Comment #2: Globbing Safety Check
+**Priority:** 🟡 MEDIUM | **Impact:** 🟡 MEDIUM | **Effort:** 🟢 LOW
+
+**Issue:** Globbing `"$PROJECTS_DIR/features"/*/` may fail if no directories exist, causing unexpected behavior.
+
+**Root Cause:** Bash globbing behavior when no matches are found - the glob pattern itself becomes the result.
+
+**Recommended Fix:**
+```bash
+# Current (problematic)
+for project_dir in "$PROJECTS_DIR/features"/*/; do
+
+# Fixed (safe)
+feature_dirs=( "$PROJECTS_DIR/features"/*/ )
+if [ -d "${feature_dirs[0]}" ]; then
+    for project_dir in "${feature_dirs[@]}"; do
+```
+
+**Impact:** Prevents script errors when no project directories exist.
+
+---
+
+## 🎯 Overall Comments Analysis
+
+### 1. CI Artifact Upload Issue ✅ FIXED
+**Priority:** 🟡 MEDIUM | **Impact:** 🟡 MEDIUM | **Effort:** 🟢 LOW
+
+**Issue:** CI workflow artifact upload grabs script and template files instead of validation logs.
+
+**Status:** ✅ **FIXED** - Addressed in PR #46 with proper output capture.
+
+### 2. Externalize Configuration
+**Priority:** 🟢 LOW | **Impact:** 🟡 MEDIUM | **Effort:** 🟡 MEDIUM
+
+**Issue:** Hard-coded lists of templates and required sections could be externalized into config.
+
+**Recommendation:** Consider YAML/JSON config for template definitions in future enhancement.
+
+### 3. Refactor Large Script
+**Priority:** 🟢 LOW | **Impact:** 🟡 MEDIUM | **Effort:** 🟠 HIGH
+
+**Issue:** Large bash script could be refactored into smaller, reusable functions.
+
+**Recommendation:** Consider modularization in future maintenance cycles.
+
+---
+
+## 🚀 Recommended Action Plan
+
+### Phase 1: Critical Fixes (Immediate)
+1. **Fix Comment #1** - Anchor grep patterns to prevent false positives (MEDIUM priority)
+2. **Fix Comment #2** - Add globbing safety checks (MEDIUM priority)
+
+### Phase 2: Quality Improvements (Next Sprint)
+3. **Address Overall Comment #2** - Externalize configuration (LOW priority)
+4. **Address Overall Comment #3** - Refactor script into modules (LOW priority)
+
+**Estimated Total Effort:** 30 minutes for critical fixes, 2-3 hours for all improvements.
+
+---
+
+## 🎯 Conclusion
+
+**Sourcery identified 2 valid issues with the template validation script.** Both are medium priority and low effort fixes that will improve the script's reliability and accuracy. The CI artifact issue has already been addressed in PR #46.
+
+**Ready to implement the remaining fixes!** 🚀
 
 


### PR DESCRIPTION
## 🐛 Fix: Template Validation Artifacts Missing Output

### 📋 Issue
**Source:** Cursor Bugbot feedback on PR #45

The template-validation job's artifact upload was configured to include source files (scripts/validate-templates.sh and the templates directory) instead of actual validation output. As the validation script prints to stdout/stderr and doesn't generate files, the uploaded artifact wouldn't contain useful debugging information for failures.

### 🔧 Solution
Updated the CI workflow to properly capture and upload the actual validation output:

#### Changes Made:
1. **Capture Output to File:**
   - Redirect stdout/stderr to `validation-output.txt`
   - Include exit code in output for better debugging
   - Create dedicated `template-validation-results` directory

2. **Upload Actual Results:**
   - Upload validation results directory instead of source files
   - Include complete validation output with exit codes
   - Provide useful debugging information when validation fails

### 📊 Before vs After

#### Before:
```yaml
- name: Upload validation results
  uses: actions/upload-artifact@v4
  with:
    name: template-validation-results
    path: |
      scripts/validate-templates.sh
      admin/planning/notes/opportunities/external/administration/templates/
```

#### After:
```yaml
- name: Run template validation
  run: |
    chmod +x scripts/validate-templates.sh
    mkdir -p template-validation-results
    ./scripts/validate-templates.sh > template-validation-results/validation-output.txt 2>&1
    echo "Template validation exit code: $?" >> template-validation-results/validation-output.txt

- name: Upload validation results
  uses: actions/upload-artifact@v4
  with:
    name: template-validation-results
    path: template-validation-results/
```

### 🧪 Testing
- ✅ Local testing completed - output captured correctly
- ✅ Validation output includes complete results and exit code
- ✅ Artifacts now contain useful debugging information

### 📈 Impact
- **Debugging:** Much better debugging experience when validation fails
- **Transparency:** Complete validation output available in artifacts
- **Reliability:** Exit code tracking for better error diagnosis
- **Maintainability:** Clear separation between source files and validation results

### 🔗 Related
- **Addresses:** Cursor Bugbot feedback on PR #45
- **Documentation:** Added Cursor Bugbot review analysis
- **Type:** Bug fix for CI workflow

---

**Ready for review and merge!** 🚀

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the CI template-validation job to capture stdout/stderr (with exit code) into a results directory and upload that directory as the artifact.
> 
> - **CI/CD**:
>   - **Template Validation**: 
>     - Redirects `scripts/validate-templates.sh` output to `template-validation-results/validation-output.txt` and appends the exit code.
>     - Creates `template-validation-results/` and uploads it via `actions/upload-artifact` instead of source files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77f2eea8bad9b86befd2e72c40c348dd783f0eb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Fix the CI workflow to capture and upload real template validation output by adding a dedicated validation script, integrating it as a CI job, and providing user-facing documentation.

New Features:
- Introduce a template-validation CI job that runs the validation script and uploads its log output as an artifact
- Add a comprehensive Bash script to validate template existence, structure, project compliance, and consistency
- Provide a user-facing TEMPLATE-VALIDATION guide with quick start, configuration, and troubleshooting sections

Enhancements:
- Update phase-3 documentation to mark template validation as complete with actual dates and results

Documentation:
- Add detailed Template Validation Guide in docs/validation
- Include Cursor Bugbot and Sourcery feedback analyses for PR #45